### PR TITLE
タイムゾーンとロケールの設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,11 @@ module Baukis2
   class Application < Rails::Application
     config.load_defaults 6.0
 
-    config.time_zone = "Tokyo"
+    config.time_zone = "Tokyo" #日本時間に設定（世界時間で9時間の時差がある為。）
     config.i18n.load_path +=
-      Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
-    config.i18n.default_locale = :ja
+      Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s] 
+      #(国際化の為のデータファイル)のロードパスを設定。
+      #config/localesディレクトリー以下を再起的に読み込む設定。
+    config.i18n.default_locale = :ja #日本語の設定。
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,12 +8,11 @@ Bundler.require(*Rails.groups)
 
 module Baukis2
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.time_zone = "Tokyo"
+    config.i18n.load_path +=
+      Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
+    config.i18n.default_locale = :ja
   end
 end


### PR DESCRIPTION
WHAT
ローケルファイルの設定、日本時間、日本語の設定。
WHY
RailsアプリケーションはデフォルトでUTC（協定世界時）を使用している為、アプリ内のタイムゾーンを東京に設定する事で日付と時刻が日本時間にすることが出来る。

国際化（i18n）のためのデータファイル（ロケールファイル）のロードパスを設定しています。config/localesディレクトリ以下のすべての.rbと.ymlファイルを再帰的に読み込むように設定しています。国際化は、アプリケーションのメッセージやテキストを複数の言語に対応させるための仕組みであり、ロケールファイルには言語ごとのテキストの翻訳などが含まれる。

アプリケーションのデフォルトの言語が日本語に設定する為です。
