### PR TITLE
必要ない自動テストファイルの設定をする事で無駄なファイルを作らない為の設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,14 @@ module Baukis2
       #(国際化の為のデータファイル)のロードパスを設定。
       #config/localesディレクトリー以下を再起的に読み込む設定。
     config.i18n.default_locale = :ja #日本語の設定。
+
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.assets false
+      g.test_framework :rspec
+      g.controllar_specs false
+      g.view_specs false
+    end
   end
 end


### PR DESCRIPTION
WHAT
自動生成されるテストファイルを無効にする設定。
WHY
今回はRspecを用いたテストを実行する為、mini_testからRSpecに変更する以外では全てのジェネレーターによるソースコードの生成をoffに設定することで必要ないファイルを自動生成することを防ぐことが出来る。