### PR TITLE
アクセス制御

### DIFF
--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,6 +1,5 @@
 class Admin::Base < ApplicationController
   before_action :authorize
-
   private def current_administrator
     if session[:administrator_id]
       @current_administrator ||=

--- a/app/controllers/admin/base.rb
+++ b/app/controllers/admin/base.rb
@@ -1,4 +1,6 @@
 class Admin::Base < ApplicationController
+  before_action :authorize
+
   private def current_administrator
     if session[:administrator_id]
       @current_administrator ||=
@@ -6,4 +8,11 @@ class Admin::Base < ApplicationController
     end
   end
   helper_method :current_administrator
+
+  private def authorize
+    unless current_administrator
+      flash.alert "管理者としてログインしてください。"
+      redirect_to :admin_login
+    end
+  end  
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Admin::SessionsController < Admin::Base
+  skip_before_action :authorize
     def new 
       if current_administrator
         redirect_to :admin_root

--- a/app/controllers/admin/staff_members_controller.rb
+++ b/app/controllers/admin/staff_members_controller.rb
@@ -1,4 +1,6 @@
 class Admin::StaffMembersController < Admin::Base
+  before_action :authorize
+
   def index
     @staff_members = StaffMember.order(:family_name_kana, :given_name_kana)
   end
@@ -34,6 +36,14 @@ class Admin::StaffMembersController < Admin::Base
       render action: "edit"
     end
   end
+
+  private def authorize
+    unless current_administrator
+      flash.alert = "管理者としてログインしてください。"
+      redirect_to :admin_login
+    end
+  end
+
   private def staff_member_params
     params.require(:staff_member).permit(
       :email, :password, :family_name, :given_name, 

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,4 +1,5 @@
 class Admin::TopController < Admin::Base
+  skip_before_action :authorize
   def index
     if current_administrator
       render action: "dashboard"

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -1,4 +1,6 @@
 class Staff::Base < ApplicationController
+  before_action :authorize
+
   private def current_staff_member
     if session[:staff_member_id]
       @current_staff_member ||=
@@ -7,4 +9,19 @@ class Staff::Base < ApplicationController
   end
 
   helper_method :current_staff_member
+
+  private def authorize
+    unless current_staff_member
+      flash.alert = "職員としてログインしてください。"
+      redirect_to :staff_login
+    end
+  end
+
+  private def check_account
+    if current_staff_member && !current_staff_member.active?
+      session.delete(:staff_member_id)
+      flash.alert = "アカウントが無効になりました。"
+      redirect_to :staff_root
+    end
+  end
 end

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -31,7 +31,7 @@ class Staff::Base < ApplicationController
 
   private def check_timeout
     if current_staff_member
-      if session[:last_access_time] >= TIMEOUT.admin_login
+      if session[:last_access_time] >= TIMEOUT.ago
         session[:last_access_time] = Time.current
       else
         session.delete(:staff_membender_id)

--- a/app/controllers/staff/base.rb
+++ b/app/controllers/staff/base.rb
@@ -1,5 +1,7 @@
 class Staff::Base < ApplicationController
   before_action :authorize
+  before_action :check_account
+  before_action :check_timeout
 
   private def current_staff_member
     if session[:staff_member_id]
@@ -22,6 +24,20 @@ class Staff::Base < ApplicationController
       session.delete(:staff_member_id)
       flash.alert = "アカウントが無効になりました。"
       redirect_to :staff_root
+    end
+  end
+
+  TIMEOUT = 60.minutes
+
+  private def check_timeout
+    if current_staff_member
+      if session[:last_access_time] >= TIMEOUT.admin_login
+        session[:last_access_time] = Time.current
+      else
+        session.delete(:staff_membender_id)
+        flash.alert = "セッションがタイムアウトしました。"
+        redirect_to :staff_login
+      end
     end
   end
 end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -21,6 +21,7 @@ class Staff::SessionsController < Staff::Base
         render action: "new"
       else
         session[:staff_member_id] = staff_member.id
+        session[:last_access_time] = Time.current
         flash.notice = "ログインしました。"
         redirect_to :staff_root
       end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Staff::SessionsController < Staff::Base
+  skip_before_action :authorize
   def new 
     if  current_staff_member
       redirect_to :staff_root

--- a/app/controllers/staff/top_controller.rb
+++ b/app/controllers/staff/top_controller.rb
@@ -1,4 +1,5 @@
 class Staff::TopController < Staff::Base
+  skip_before_action :authorize
   def index
     render action: "index"
   end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -6,4 +6,9 @@ class StaffMember < ApplicationRecord
       self.hashed_password = nil
     end
   end
+
+  def active?
+    !suspended? && start_date <= Date.today &&
+      (end_date.nil? || end_date > Date.today)
+  end
 end

--- a/spec/requests/admin/staff_members_management_spec.rb
+++ b/spec/requests/admin/staff_members_management_spec.rb
@@ -3,6 +3,15 @@ require "rails_helper"
 describe "管理者による職員管理" do
   let(:administrator) { create(:administrator) }
 
+  before do
+    post  admin_session_url,
+      params: {
+        admin_login_forn: {
+          email: administrator.email,
+          password: "pw"
+        }
+      }
+  end
   describe "新規登録" do
     let(:params_hash) { attributes_for(:staff_member) }
 

--- a/spec/requests/admin/staff_members_management_spec.rb
+++ b/spec/requests/admin/staff_members_management_spec.rb
@@ -6,7 +6,7 @@ describe "管理者による職員管理" do
   before do
     post  admin_session_url,
       params: {
-        admin_login_forn: {
+        admin_login_form: {
           email: administrator.email,
           password: "pw"
         }


### PR DESCRIPTION
WHAT
ログインしているかしてないかアクセス制限を行う。
ログインしてから60分以内かどうかを確かめて時間外であれば、強制的にログアウトさせるようにする。

WHY
今の機能では、パスを指定すればログインしてなくてもログインページに飛ぶことができるため、セキュリティの強化をし悪意のあるユーザーからアプリケーションを守る為。
