### PR TITLE
Cp14 値の正規表現とバリデーション

### DIFF
--- a/app/assets/stylesheets/admin/_colors.scss
+++ b/app/assets/stylesheets/admin/_colors.scss
@@ -10,6 +10,6 @@ $very_dark_magenta: darken($dark_magenta, 25%);
 
 /* 赤系 */
 $red: #cc0000;
-
+$pink: #ffcccc;
 /* 緑系 */ 
 $green: #00cc00;

--- a/app/assets/stylesheets/admin/form.scss
+++ b/app/assets/stylesheets/admin/form.scss
@@ -40,6 +40,12 @@ div#wrapper {
             padding: $wide $wide * 2;
           }
         }
+        div.field_with_errors {
+          display: inline;
+          padding: 0;
+          label { color: $red;}
+          input { background-color: $pink;}
+        }
       }
     }
   }

--- a/app/assets/stylesheets/staff/_colors.scss
+++ b/app/assets/stylesheets/staff/_colors.scss
@@ -12,6 +12,6 @@ $very_dark_cyan: darken($dark_cyan, 25%);
 /* 赤系 */
 
 $red: #cc0000;
-
+$pink: #ffcccc;
 /* 緑系 */ 
 $green: #00cc00;

--- a/app/assets/stylesheets/staff/form.scss
+++ b/app/assets/stylesheets/staff/form.scss
@@ -40,6 +40,12 @@ div#wrapper {
             padding: $wide $wide * 2;
           }
         }
+        div.field_with_errors {
+          display: inline;
+          padding: 0;
+          ladel { color: $red; }
+          input { background-color: $pink;}
+        }
       }
     }
   }

--- a/app/assets/stylesheets/staff/tables.scss
+++ b/app/assets/stylesheets/staff/tables.scss
@@ -19,7 +19,7 @@ div.table-wrapper {
         color: $very_light_gray;
       }
       th, td { padding: $narrow; }
-      td.email, td.date { font-family: monospace; }
+      td.email, td.date, td.password { font-family: monospace; }
       td.boolean { text-align: center;}
       td.actions {
         text-align: center;

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -7,4 +7,22 @@ class Staff::PasswordsController < Staff::Base
     @change_password_form =
       Staff::ChangePasswordForm.new(object: current_staff_member)
   end
+
+  def update
+    @change_password_form = Staff::ChangePasswordForm.new(staff_member_params)
+    @change_password_form.object = current_staff_member
+    if @change_password_form.save
+      flash.notice = "パスワードを変更しました。"
+      redirect_to :staff_account
+    else
+      flash.now.alert = "入力に誤りがあります。"
+      render action: "edit"
+    end
+  end
+
+  private def staff_member_params
+    params.require(:staff_change_password_form).permit(
+      :current_password, :new_password, :new_password_confirmation
+    )
+  end
 end

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -2,4 +2,9 @@ class Staff::PasswordsController < Staff::Base
   def show
     redirect_to :edit_staff_password
   end
+
+  def edit
+    @change_password_form =
+      Staff::ChangePasswordForm.new(object: current_staff_member)
+  end
 end

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -1,0 +1,5 @@
+class Staff::PasswordsController < Staff::Base
+  def show
+    redirect_to :edit_staff_password
+  end
+end

--- a/app/forms/staff/change_password_form.rb
+++ b/app/forms/staff/change_password_form.rb
@@ -1,5 +1,5 @@
 class Staff::ChangePasswordForm
-  include ActiveModel::model
+  include ActiveModel::Model
 
   attr_accessor :object, :current_password, :new_password,
     :new_password_confirmation

--- a/app/forms/staff/change_password_form.rb
+++ b/app/forms/staff/change_password_form.rb
@@ -1,0 +1,11 @@
+class Staff::ChangePasswordForm
+  include ActiveModel::model
+
+  attr_accessor :object, :current_password, :new_password,
+    :new_password_confirmation
+
+  def save 
+    object.password = new_password
+    object.save!
+  end
+end

--- a/app/forms/staff/change_password_form.rb
+++ b/app/forms/staff/change_password_form.rb
@@ -3,9 +3,19 @@ class Staff::ChangePasswordForm
 
   attr_accessor :object, :current_password, :new_password,
     :new_password_confirmation
+  validates :new_password, presence: true, confirmation: true #_confirmationと比較して値が一致していないと失敗する。
+
+  validate do 
+    unless Staff::Authenticator.new(object).authenticate(current_password)
+      #↑Staff::Authenticatorサービスオブジェクトを介してユーザーが入力した正しいパスワードかチェックする
+      errors.add(:current_password, :wrong)
+    end
+  end
 
   def save 
-    object.password = new_password
-    object.save!
+    if valid?
+      object.password = new_password
+      object.save!
+    end
   end
 end

--- a/app/models/concerns/string_normalizer.rb
+++ b/app/models/concerns/string_normalizer.rb
@@ -1,0 +1,13 @@
+require "nkf"
+
+module StringNormalizer
+  extend ActiveSupport::Concern
+
+  def normalize_as_name(text)
+    NKF.nkf("-W -w -Z1 --katakana", text).strip if text
+  end
+
+  def normalize_as_furigana(text)
+    NKF.nkf("-W -w -Z1 --katakana", text).strip if text
+  end
+end

--- a/app/models/concerns/string_normalizer.rb
+++ b/app/models/concerns/string_normalizer.rb
@@ -3,6 +3,10 @@ require "nkf"
 module StringNormalizer
   extend ActiveSupport::Concern
 
+  def normalize_as_email(text)
+    NKF.nkf("-W -w -Z1", text).strip if text
+  end
+  
   def normalize_as_name(text)
     NKF.nkf("-W -w -Z1 --katakana", text).strip if text
   end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -2,7 +2,9 @@ class StaffMember < ApplicationRecord
   include StringNormalizer
   
   has_many :events, class_name: "StaffEvent", dependent: :destroy
+
   before_validation do 
+    self.email = normalize_as_email(email)
     self.family_name = normalize_as_name(family_name)
     self.given_name = normalize_as_name(given_name)
     self.family_name_kana = normalize_as_name(family_name_kana)
@@ -11,6 +13,8 @@ class StaffMember < ApplicationRecord
 
   KATAKANA_REGEXP = /\A[\p{katakana}\u{30fc}]+\z/
 
+  validates :email, presence: true, "valid_email_2/email": true,
+    uniqueness: { case_sensitive: false }
   validates :family_name, :given_name, presence: true
   validates :family_name_kana, :given_name_kana, presence: true,
     format: { with: KATAKANA_REGEXP, allow_blank: true }

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -10,12 +10,13 @@ class StaffMember < ApplicationRecord
     self.family_name_kana = normalize_as_name(family_name_kana)
     self.given_name_kana = normalize_as_name(given_name_kana)
   end
-
+  HUMAN_NAME_REGEXP = /\A[\p{han}\p{hiragana}\p{katakana}\u{30fc}A-Za-z]+\z/
   KATAKANA_REGEXP = /\A[\p{katakana}\u{30fc}]+\z/
 
   validates :email, presence: true, "valid_email_2/email": true,
     uniqueness: { case_sensitive: false }
-  validates :family_name, :given_name, presence: true
+  validates :family_name, :given_name, presence: true,
+    format: { with: HUMAN_NAME_REGEXP, allow_blank: true }
   validates :family_name_kana, :given_name_kana, presence: true,
     format: { with: KATAKANA_REGEXP, allow_blank: true }
   validates :start_date, presence: true, date: {

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -1,5 +1,29 @@
 class StaffMember < ApplicationRecord
+  include StringNormalizer
+  
   has_many :events, class_name: "StaffEvent", dependent: :destroy
+  before_validation do 
+    self.family_name = normalize_as_name(family_name)
+    self.given_name = normalize_as_name(given_name)
+    self.family_name_kana = normalize_as_name(family_name_kana)
+    self.given_name_kana = normalize_as_name(given_name_kana)
+  end
+
+  KATAKANA_REGEXP = /\A[\p{katakana}\u{30fc}]+\z/
+
+  validates :family_name, :given_name, presence: true
+  validates :family_name_kana, :given_name_kana, presence: true,
+    format: { with: KATAKANA_REGEXP, allow_blank: true }
+  validates :start_date, presence: true, date: {
+    after_or_equal_to: Date.new(2000, 1, 1),
+    before: -> (obj) { 1.year.from_now.to_date },
+    allow_blank: true
+  }
+  validates :end_date, date: { 
+    after: :start_date,
+    before: -> (obj) {1.year.from_now.to_date },
+    allow_blank:true
+  }  
 
   def password=(raw_password)
     if raw_password.kind_of?(String) 

--- a/app/views/staff/accounts/show.html.erb
+++ b/app/views/staff/accounts/show.html.erb
@@ -3,7 +3,8 @@
 
 <div class="table-wrapper">
   <div class="links">
-    <%= link_to "アカウント情報編集", :edit_staff_account %>
+    <%= link_to "アカウント情報編集", :edit_staff_account %> |
+    <%= link_to "パスワード変更", :edit_staff_password %>
   </div>
 
   <table class="attributes">
@@ -26,6 +27,10 @@
       <td class="email">
         <%= @staff_member.email %>
       </td>
+    </tr>
+    <tr>
+      <th>パスワード</th>
+      <td class="password">***********</td>
     </tr>
     <tr>
       <th>入社日</th>

--- a/app/views/staff/passwords/edit.html.erb
+++ b/app/views/staff/passwords/edit.html.erb
@@ -1,0 +1,22 @@
+<% @title = "パスワード変更" %>
+<h1><%= @title %></h1>
+<div id="generic-form">
+  <%= form_with model: @change_password_form, url: :staff_password, method: :patch do |f| %>
+    <div>
+      <%= f.label :current_password, "現在のパスワード" %>
+      <%= f.password_field :current_password, size: 32, required: true %>
+    </div>
+    <div>
+      <%= f.label :new_password, "新しいパスワード" %>
+      <%= f.password_field :new_password, size: 32, required: true %>
+    </div>
+    <div>
+      <%= f.label :new_password_confirmation, "新しいパスワード（確認）" %>
+      <%= f.password_field :new_password_confirmation, size: 32, required: true %>
+    </div>
+    <div class="buttons">
+      <%= f.submit  "変更" %>
+      <%= link_to  "キャンセル", :staff_account %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       get "login" => "sessions#new", as: :login
       resource :session, onry: [ :create, :destroy ]
       resource :account, except: [ :new, :create, :destroy ]
+      resource :password, only: [ :show, :edit, :update ]
     end
   end
 

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -15,4 +15,54 @@ RSpec.describe StaffMember, type: :model do
       expect(member.hashed_password).to be_nil
     end
   end
+
+  describe "値の正規化" do
+    example "email前後の空白を除去" do
+      member = create(:staff_member, email: " test@example.com ")
+      expect(member.email).to eq("test@example.com")
+    end
+
+    example "emailに含まれる全角英数字記号を半角に変換" do 
+      member = create(:staff_member, email: "ｔｅｓｔ＠ｅｘａｍｐｌｅ．ｃｏｍ")
+      expect(member.email).to eq("test@example.com")
+    end
+
+    example "email前後の全角スペースを除去" do
+      member = create(:staff_member, email: "\u{3000}test@example.com\u{3000}")
+      expect(member.email).to eq("test@example.com")
+    end
+
+    example "family_name_kanaに含まれるひらがなをカタカナに変換" do
+      member = create(:staff_member, family_name_kana: "てすと")
+      expect(member.family_name_kana).to eq("テスト")
+    end
+
+    example "family_name_kanaに含まれる半角カナを全角カナに変換" do
+      member = create(:staff_member, family_name_kana: "ﾃｽﾄ")
+      expect(member.family_name_kana).to eq("テスト")
+    end
+  end
+
+  describe "バリデーション" do
+    example "@を２個含む emailは無効" do
+      member = build(:staff_member, email: "test@@example.com")
+      expect(member).not_to be_valid
+    end
+
+    example "漢字を含むfamily_name_kanaは無効" do
+      member = build(:staff_member, family_name_kana: "試験")
+      expect(member).not_to be_valid
+    end
+
+    example "長音符を含むfamily_name_kanaは有効" do
+      member = build(:staff_member, family_name_kana: "エリー")
+      expect(member).to be_valid
+    end
+
+    example "他の職員のメールアドレスと重複したemailは無効" do
+      member1 = create(:staff_member)
+      member2 = build(:staff_member, email: member1.email)
+      expect(member2).not_to be_valid
+    end
+  end
 end

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe StaffMember, type: :model do
       expect(member).not_to be_valid
     end
 
+    example "アルファベット表記のfamily_nameは有効" do
+      member = build(:staff_member, family_name: "Smith")
+      expect(member).to be_valid
+    end
+
+    example "記号を含むfamily_nameは無効" do
+      member = build(:staff_member, family_name: "???")
+      expect(member).not_to be_valid
+    end
     example "漢字を含むfamily_name_kanaは無効" do
       member = build(:staff_member, family_name_kana: "試験")
       expect(member).not_to be_valid

--- a/spec/requests/staff/passwords_spec.rb
+++ b/spec/requests/staff/passwords_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Staff::Passwords", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
WHAT
アプリケーションの使用通りに適切なデータを入れるため、各種バリデーションの設定をして仕様通りにする。
職員スタッフが自らPWを変更更新できるようにする。
WHY
不正なアドレスや登録に時に適切でない文字を受け入れないようにする為、現時点でパスワードの変更、更新ができない為職員自身で変更できるようにするため。